### PR TITLE
run remove_hash processor before dump.to_zip

### DIFF
--- a/planner/nodes/output_nodes.py
+++ b/planner/nodes/output_nodes.py
@@ -16,7 +16,8 @@ class OutputToZipProcessingNode(BaseProcessingNode):
             output = ProcessingArtifact(
                 datahub_type, resource_name,
                 [], self.available_artifacts,
-                [('dump.to_zip', {
+                [('assembler.remove_hash', {}),
+                 ('dump.to_zip', {
                     'out-file': out_file,
                     'force-format': False,
                     'handle-non-tabular': True}),


### PR DESCRIPTION
This pull request refs https://github.com/datahq/assembler/issues/65

run remoev_hash processor before `dump.to_zip`