### PR TITLE
Private datasets

### DIFF
--- a/planner/planner.py
+++ b/planner/planner.py
@@ -106,12 +106,6 @@ def _plan(revision, spec, **config):
         ('assembler.sample',),
     ]
     final_steps.extend(dump_steps(ownerid, dataset, 'latest', final=True))
-    if not os.environ.get('PLANNER_LOCAL'):
-        final_steps.append(('aws.change_acl', {
-            'bucket': os.environ['PKGSTORE_BUCKET'],
-            'path': '{}/{}'.format(ownerid, dataset),
-            'acl': acl
-        }))
     final_steps.append(('assembler.add_indexing_resource', {
         'flow-id': pipeline_id()
     }))
@@ -134,6 +128,12 @@ def _plan(revision, spec, **config):
              }
          })
     )
+    if not os.environ.get('PLANNER_LOCAL'):
+        final_steps.append(('aws.change_acl', {
+            'bucket': os.environ['PKGSTORE_BUCKET'],
+            'path': '{}/{}'.format(ownerid, dataset),
+            'acl': acl
+        }))
     pipeline = {
         'update_time': update_time,
         'dependencies': dependencies,

--- a/planner/planner.py
+++ b/planner/planner.py
@@ -51,6 +51,23 @@ def _plan(revision, spec, **config):
         }
         outputs.append(zip_output)
 
+    first_step = []
+    if not os.environ.get('PLANNER_LOCAL'):
+        first_step.append(('aws.change_acl', {
+            'bucket': os.environ['PKGSTORE_BUCKET'],
+            'path': '{}/{}'.format(ownerid, dataset),
+            'acl': 'private'
+        }))
+    pipeline_acl = {
+        'update_time': update_time,
+        'dependencies': [],
+        'pipeline': steps(*first_step),
+        'hooks': [FLOWMANAGER_HOOK_URL]
+    }
+    change_privacy_id = pipeline_id('change_privacy')
+
+    yield change_privacy_id, pipeline_acl
+
     def planner_pipelines():
         planner_gen = planner(input,
                               spec.get('processing', []),
@@ -70,6 +87,7 @@ def _plan(revision, spec, **config):
                 '/{}/'.format(revision), '/')
             pipeline_steps.extend(dump_steps(path_without_revision))
             dependencies = [dict(pipeline=pipeline_id(r)) for r in dependencies]
+            dependencies.append(dict(pipeline=change_privacy_id))
 
             pipeline = {
                 'pipeline': steps(*pipeline_steps),
@@ -81,6 +99,7 @@ def _plan(revision, spec, **config):
     yield from planner_pipelines()
 
     dependencies = [dict(pipeline=pid) for pid in inner_pipeline_ids]
+    dependencies.append(dict(pipeline=change_privacy_id))
     # print(dependencies)
     final_steps = [
         ('load_metadata',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -43,3 +43,14 @@ def test_only_one_sink(spec, config):
     assert get_flow_sink(flow) is not None
 
 
+@pytest.mark.parametrize('spec', SPECS)
+@pytest.mark.parametrize('config', CONFIGS)
+def test_change_privacy_is_dependency_for_any_pipeline(spec, config):
+    """Tests that the generated grapיh has different pipline ids"""
+    flow = planner.plan(1, spec, **config)
+    pipeline_deps = [
+        pipeline['dependencies'] for pipeline_id, pipeline in flow \
+            if 'change_privacy' not in pipeline_id
+    ]
+    for deps in pipeline_deps:
+        assert any('change_privacy' in dep['pipeline'] for dep in deps)

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -6,4 +6,3 @@ def get_flow_sink(flow):
     if len(dependents) == len(flow) - 1:
         return [(pipeline_id, pipeline) for pipeline_id, pipeline in flow if pipeline_id not in dependents][0]
     return None
-


### PR DESCRIPTION
changes ACL to `public-read` before run any other pipeline so that while executing processors for private datasets assembler is able to read data 