### PR TITLE
Support dpp built-in processors as processing steps 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,23 @@ inputs:
       descriptor: <datapackage-descriptor>
       resource-mapping:
         <resource-name-or-path>: <resource-url>
-        
+
 processing:
  - # Processing steps that need to be done on sources to get proper data streams
    input: <source-resource-name - e.g. `my-excel-resource`>
    output: <destination-resource-name - e.g. `my-excel-resource-sheet-1`>
-   tabulator: # Currently we're only supporting tabulator transformations
+   tabulator:
      # These are sample options for tabulator, see its docs for all available options
-     headers: 2 
+     headers: 2
      sheet: 1
+ -
+   input: <source-resource-name - e.g. `my-excel-resource`>
+   output: <destination-resource-name - e.g. `my-excel-resource-sheet-1`>
+   dpp:
+     - run: sort
+       parameters:
+         resources: resource1
+         sort-by: fullname
 
 outputs:
   -
@@ -44,7 +52,7 @@ outputs:
       credentials: <tbd, should be the name of a user provided configuration - not the actual credentials>
   -
     kind: zip (dump.to_zip)
-    parameters: 
+    parameters:
         out-file: <name of the file>
   - ... # other output formats
 schedule: 'every 1d' # s/m/h/d/w (second -> week)

--- a/planner/nodes/planner.py
+++ b/planner/nodes/planner.py
@@ -103,6 +103,11 @@ def planner(datapackage_input, processing, outputs, allowed_types=None):
                     ri_.update(p['tabulator'])
                 if 'schema' in p:
                     ri_['schema'] = p['schema']
+                # Insert dpp in resource info for a while
+                if 'dpp' in p:
+                    ri_['dpp'] = [
+                        (i['run'], i.get('parameters', {})) for i in p['dpp']
+                    ]
                 ri_['name'] = p['output']
                 ri_['datahub']['type'] = 'source/tabular'
                 updated_resource_info.append(ri_)
@@ -117,16 +122,14 @@ def planner(datapackage_input, processing, outputs, allowed_types=None):
         ProcessingArtifact(ri['datahub']['type'],
                            ri['name'],
                            [], [],
-                           [],
+                           ri.pop('dpp', []),  # pop dpp form resource_info here
                            False)
         for ri in resource_info.values()
     ]
-
     for derived_artifact in collect_artifacts(artifacts, outputs, allowed_types):
         pipeline_steps: List[Tuple] = [
             ('add_metadata', {'name': derived_artifact.resource_name}),
         ]
-        needs_streaming = False
         for required_artifact in derived_artifact.required_streamed_artifacts:
             ri = resource_info[required_artifact.resource_name]
             if 'resource' in ri:
@@ -137,17 +140,13 @@ def planner(datapackage_input, processing, outputs, allowed_types=None):
                         'stream': True
                     })
                 )
+                pipeline_steps.extend(required_artifact.pipeline_steps)
             else:
-                pipeline_steps.append(
-                    ('add_resource', ri)
-                )
-                needs_streaming = True
+                pipeline_steps.extend([
+                    ('add_resource', ri),
+                    ('stream_remote_resources',)
+                ] + required_artifact.pipeline_steps)
 
-        if needs_streaming:
-            pipeline_steps.extend([
-                ('assembler.sample',),
-                ('stream_remote_resources',)
-            ])
 
         for required_artifact in derived_artifact.required_other_artifacts:
             ri = resource_info[required_artifact.resource_name]

--- a/planner/nodes/planner.py
+++ b/planner/nodes/planner.py
@@ -147,7 +147,6 @@ def planner(datapackage_input, processing, outputs, allowed_types=None):
                     ('stream_remote_resources',)
                 ] + required_artifact.pipeline_steps)
 
-
         for required_artifact in derived_artifact.required_other_artifacts:
             ri = resource_info[required_artifact.resource_name]
             if 'resource' in ri:


### PR DESCRIPTION
This pull request fixes #14

* able to pass dpp processors with the same syntax that it would be defined in pipeline-spec.yaml
* add pipeline_steps (if any) of required artefacts to run before they are streamed further
