### PR TITLE
Keep metadata from original descriptor for all derived resources 

### DIFF
--- a/planner/nodes/planner.py
+++ b/planner/nodes/planner.py
@@ -128,7 +128,7 @@ def planner(datapackage_input, processing, outputs, allowed_types=None):
     ]
     for derived_artifact in collect_artifacts(artifacts, outputs, allowed_types):
         pipeline_steps: List[Tuple] = [
-            ('add_metadata', {'name': derived_artifact.resource_name}),
+            ('load_metadata', {'url': datapackage_input['url']}),
         ]
 
         required_artifact_pipeline_steps = []


### PR DESCRIPTION
fixes https://github.com/datahq/assembler/issues/81

Loading metadata from original datapackage.json instead of creating it from the scratch 

This info will be common for all derived resources including zip. Meaning All derived resources have datapackage.json with exactly same metadata but different resources inside