### PR TITLE
[zip][xs]: add extract_readme processor for zip

### DIFF
--- a/planner/nodes/output_nodes.py
+++ b/planner/nodes/output_nodes.py
@@ -22,7 +22,8 @@ class OutputToZipProcessingNode(BaseProcessingNode):
             output = ProcessingArtifact(
                 datahub_type, resource_name,
                 [], self.available_artifacts,
-                [('assembler.remove_hash', {}),
+                [('assembler.extract_readme', {}),
+                 ('assembler.remove_hash', {}),
                  ('dump.to_zip', {
                     'out-file': tmp_zip,
                     'force-format': False,


### PR DESCRIPTION
This pull request fixes #26 

Part of https://github.com/datahq/assembler/pull/92

Include newly introduced processor into the zip node