### PR TITLE
Introduce content_types in ProcessingArtifacts - fixes #31

### DIFF
--- a/planner/nodes/base_processing_node.py
+++ b/planner/nodes/base_processing_node.py
@@ -10,7 +10,8 @@ class ProcessingArtifact():
                  pipeline_steps,
                  streamable,
                  title='',
-                 limit_streamed_rows=None):
+                 limit_streamed_rows=None,
+                 content_type='application/octet-stream'):
         self.datahub_type = datahub_type
         self.resource_name = resource_name
         self.required_streamed_artifacts = required_streamed_artifacts
@@ -19,6 +20,7 @@ class ProcessingArtifact():
         self.streamable = streamable
         self.title = title
         self.limit_streamed_rows = limit_streamed_rows
+        self.content_type = content_type
 
 
 class BaseProcessingNode():

--- a/planner/nodes/basic_nodes.py
+++ b/planner/nodes/basic_nodes.py
@@ -1,3 +1,5 @@
+from mimetypes import guess_type
+
 from .base_processing_node import BaseProcessingNode, ProcessingArtifact
 
 
@@ -11,6 +13,8 @@ class DerivedFormatProcessingNode(BaseProcessingNode):
             if artifact.datahub_type == 'source/tabular':
                 datahub_type = 'derived/{}'.format(self.fmt)
                 resource_name = artifact.resource_name + '_{}'.format(self.fmt)
+                file_path = 'data/{}.{}'.format(resource_name, self.fmt)
+                content_type, _ = guess_type(file_path)
                 output = ProcessingArtifact(
                     datahub_type, resource_name,
                     [artifact], [],
@@ -20,7 +24,7 @@ class DerivedFormatProcessingNode(BaseProcessingNode):
                           'update': {
                               'name': resource_name,
                               'format': self.fmt,
-                              'path': 'data/{}.{}'.format(resource_name, self.fmt),
+                              'path': file_path,
                               'datahub': {
                                 'type': datahub_type,
                                 'derivedFrom': [
@@ -30,7 +34,8 @@ class DerivedFormatProcessingNode(BaseProcessingNode):
                           }
                       })],
                     True,
-                    'Creating %s' % self.fmt.upper()
+                    'Creating %s' % self.fmt.upper(),
+                    content_type=content_type
                 )
                 yield output
 

--- a/planner/nodes/output_nodes.py
+++ b/planner/nodes/output_nodes.py
@@ -39,7 +39,6 @@ class OutputToZipProcessingNode(BaseProcessingNode):
                     },
                     'description': 'Compressed versions of dataset. Includes normalized CSV and JSON data with original data and datapackage.json.' #noqa
                  })],
-                False,
-                'Creating ZIP'
+                False, 'Creating ZIP', content_type='application/zip'
             )
             yield output

--- a/planner/nodes/planner.py
+++ b/planner/nodes/planner.py
@@ -183,7 +183,8 @@ def planner(datapackage_input, processing, outputs, allowed_types=None):
                         for ra in (derived_artifact.required_streamed_artifacts +
                                    derived_artifact.required_other_artifacts)
                         if ra.datahub_type not in ('source/tabular', 'source/non-tabular')]
-        datapackage_url = yield derived_artifact.resource_name, pipeline_steps, dependencies, derived_artifact.title
+        datapackage_url = yield derived_artifact.resource_name, pipeline_steps, \
+            dependencies, derived_artifact.title, derived_artifact.content_type
 
         resource_info[derived_artifact.resource_name] = {
             'resource': derived_artifact.resource_name,

--- a/planner/nodes/report_nodes.py
+++ b/planner/nodes/report_nodes.py
@@ -18,5 +18,5 @@ class ReportProcessingNode(BaseProcessingNode):
             datahub_type, resource_name,
             [], tabular_artifacts,
             [('assembler.validate_resource', {})],
-            False, 'Validating package contents')
+            False, 'Validating package contents', content_type='application/json')
         yield output

--- a/planner/nodes/view_nodes.py
+++ b/planner/nodes/view_nodes.py
@@ -34,6 +34,6 @@ class DerivedPreviewProcessingNode(BaseProcessingNode):
                       }),
                      ('assembler.load_preview', {'limit': 2000}),
                      ('assembler.load_views', {'limit': 2000})],
-                    True, 'Generating views', 2000
+                    True, 'Generating views', 2000, content_type='application/json'
                 )
                 yield output

--- a/planner/planner.py
+++ b/planner/planner.py
@@ -73,7 +73,7 @@ def _plan(revision, spec, **config):
                               **config)
         datapackage_url = None
         while True:
-            inner_pipeline_id, pipeline_steps, dependencies, title = planner_gen.send(datapackage_url)
+            inner_pipeline_id, pipeline_steps, dependencies, title, content_type = planner_gen.send(datapackage_url)
             inner_pipeline_id = pipeline_id(inner_pipeline_id)
             inner_pipeline_ids.append(inner_pipeline_id)
 
@@ -84,7 +84,7 @@ def _plan(revision, spec, **config):
             path_without_revision = inner_pipeline_id.replace(
                 '/{}/'.format(revision), '/')
             pipeline_steps.insert(0, datahub_step)
-            pipeline_steps.extend(dump_steps(path_without_revision))
+            pipeline_steps.extend(dump_steps(path_without_revision, content_type=content_type))
             dependencies = [dict(pipeline='./'+pipeline_id(r)) for r in dependencies]
 
             pipeline = {
@@ -109,7 +109,7 @@ def _plan(revision, spec, **config):
          }),
         ('assembler.sample',),
     ]
-    final_steps.extend(dump_steps(ownerid, dataset, revision, final=True))
+    final_steps.extend(dump_steps(ownerid, dataset, revision, final=True, content_type='application/json'))
     if not os.environ.get('PLANNER_LOCAL'):
         final_steps.append(('aws.change_acl', {
             'bucket': os.environ['PKGSTORE_BUCKET'],

--- a/planner/planner.py
+++ b/planner/planner.py
@@ -109,7 +109,7 @@ def _plan(revision, spec, **config):
          }),
         ('assembler.sample',),
     ]
-    final_steps.extend(dump_steps(ownerid, dataset, revision, final=True, content_type='application/json'))
+    final_steps.extend(dump_steps(ownerid, dataset, revision, content_type='application/json', final=True))
     if not os.environ.get('PLANNER_LOCAL'):
         final_steps.append(('aws.change_acl', {
             'bucket': os.environ['PKGSTORE_BUCKET'],

--- a/planner/utilities.py
+++ b/planner/utilities.py
@@ -8,7 +8,7 @@ from botocore.client import Config
 PKGSTORE_BUCKET = os.environ.get('PKGSTORE_BUCKET')
 
 
-def dump_steps(*parts, final=False, content_type=None):
+def dump_steps(*parts, content_type, final=False):
     handle_non_tabular = False if final else True
     if os.environ.get('PLANNER_LOCAL'):
         return [('dump.to_path',
@@ -18,7 +18,6 @@ def dump_steps(*parts, final=False, content_type=None):
                      'add-filehash-to-path': True,
                      'out-path': '/'.join(str(p) for p in parts),
                      'pretty-descriptor': True,
-                     'content_type': content_type,
                      'counters': {
                          "datapackage-rowcount": "datahub.stats.rowcount",
                          "datapackage-bytes": "datahub.stats.bytes",
@@ -38,6 +37,7 @@ def dump_steps(*parts, final=False, content_type=None):
                      'path': '/'.join(str(p) for p in parts),
                      'pretty-descriptor': True,
                      'acl': 'private',
+                     'content_type': content_type,
                      'final': final,
                      'counters': {
                          "datapackage-rowcount": "datahub.stats.rowcount",

--- a/planner/utilities.py
+++ b/planner/utilities.py
@@ -8,7 +8,7 @@ from botocore.client import Config
 PKGSTORE_BUCKET = os.environ.get('PKGSTORE_BUCKET')
 
 
-def dump_steps(*parts, final=False):
+def dump_steps(*parts, final=False, content_type=None):
     handle_non_tabular = False if final else True
     if os.environ.get('PLANNER_LOCAL'):
         return [('dump.to_path',
@@ -18,6 +18,7 @@ def dump_steps(*parts, final=False):
                      'add-filehash-to-path': True,
                      'out-path': '/'.join(str(p) for p in parts),
                      'pretty-descriptor': True,
+                     'content_type': content_type,
                      'counters': {
                          "datapackage-rowcount": "datahub.stats.rowcount",
                          "datapackage-bytes": "datahub.stats.bytes",


### PR DESCRIPTION
Introducing the `content_type` parameter for `ProcessingArtifacts`. Make able to set `content_type`s on demand for the resources. 

* All derived resources have appropriate `content_types`
* while resource containing source file (uploaded by user) is forced to be `application/octet-stream`